### PR TITLE
Update to use std::ops::Range instead of an index + size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ Changes:
 Changes:
 * Key type is now a generic type - no longer required to be `&str` [#2]
 * All entries must implement `BumpyVector::AutoBumpyEntry` [#3]
+* Entries are index with `std::ops::Range` instead of an `index` + `size` pair [#4]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ a great deal.
 
 ```rust
 use multi_vector::{MultiVector, AutoBumpyEntry};
+use std::ops::Range;
 
 struct MyEntryType { data: u32, index: usize, size: usize }
 impl AutoBumpyEntry for MyEntryType {
-    fn index(&self) -> usize { self.index }
-    fn size(&self) -> usize { self.size }
+    fn range(&self) -> Range<usize> { self.index..(self.index + self.size) }
 }
 
 // Create an instance that stores Strings


### PR DESCRIPTION
Once again compatible with `dev` version of `bumpy_vector`: https://github.com/h2gb/bumpy_vector/pull/14